### PR TITLE
Ajout de champs de recherche intitulé + ref + organisme

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,34 @@ function extractFrom(req) {
   return parseInt(req.query.from) || 0;
 }
 
+function isEmpty(stringVar){
+  return stringVar === '' || stringVar === undefined || stringVar === null;
+}
+
+function isAuthorizedQueryParam(queryParam){
+  return [ 'q', 'reference', 'organisme', 'intitule'].includes(queryParam);
+}
+/**
+ * 
+ * @param {*} req 
+ * @param {*} query 
+ */
+function generateMatchQueriesFromRequest(expressQuery){
+  const matchQueries = [];
+  for (let key in expressQuery) {
+    if (key !== 'from' && isAuthorizedQueryParam(key) && typeof expressQuery[key] == 'string' && !isEmpty(expressQuery[key])) {
+      const propMatch = key === 'q' ? 'content' : key;
+      matchQueries.push({
+        match: {
+          [propMatch]: expressQuery[key]
+        }
+      });
+    }
+  }
+  return matchQueries;
+
+}
+
 function getDay(datetimeISOString) {
   return datetimeISOString.split('T')[0];
 }
@@ -21,4 +49,5 @@ module.exports = {
   extractFrom,
   getDay,
   getDocCount,
+  generateMatchQueriesFromRequest
 }

--- a/views/search.handlebars
+++ b/views/search.handlebars
@@ -1,12 +1,56 @@
 <form class="ui form" action="/search">
-  <div class="field">
-    <div class="ui action input">
-      <input type="text" name="q" value="{{queryString}}">
-      <button class="ui button" type="submit">Rechercher</button>
+  <div class="fields">
+    <div class="ten wide field">
+      <input
+        type="text"
+        name="q"
+        value="{{queryString}}"
+        placeholder="Contenu"
+      />
+    </div>
+    <div class="three wide field">
+      <div class="ui input">
+        <button class="ui submit button" type="submit">Rechercher</button>
+      </div>
+    </div>
+    <div class="three wide field">
+      <div class="ui input">
+        <div
+          class="ui button"
+          type="submit"
+          onclick="searchfilters.style.display = 'flex'"
+        >Filtres</div>
+      </div>
     </div>
   </div>
-</form>
+  <div class="fields" id="searchfilters" style="display: none;">
+    <div class="four wide field">
+      <input
+        type="text"
+        name="intitule"
+        value="{{intitule}}"
+        placeholder="Intitulé"
+      />
+    </div>
+    <div class="four wide field">
+      <input
+        type="text"
+        name="reference"
+        value="{{reference}}"
+        placeholder="Référence"
+      />
+    </div>
+    <div class="four wide field">
+      <input
+        type="text"
+        name="organisme"
+        value="{{organisme}}"
+        placeholder="Organisme"
+      />
+    </div>
 
+  </div>
+</form>
 
 {{#if validQueryString}}
   {{#if nbHits}}
@@ -16,54 +60,61 @@
       <p>{{nbHits}} dossier correspond à votre recherche</p>
     {{/if}}
 
-
     {{#if pagination.previousPageIndex}}
-      <a class="ui labeled icon button" href='{{pagination.firstPageHref}}'>
+      <a class="ui labeled icon button" href="{{pagination.firstPageHref}}">
         <i class="angle double left icon"></i>
         1
       </a>
     {{else}}
-      <a class="ui labeled icon disabled button" href='{{pagination.firstPageHref}}'>
+      <a
+        class="ui labeled icon disabled button"
+        href="{{pagination.firstPageHref}}"
+      >
         <i class="angle double left icon"></i>
         1
-      </a>     
+      </a>
     {{/if}}
 
     <div class="ui buttons">
       {{#if pagination.previousPageIndex}}
-        <a class="ui labeled icon button" href='{{pagination.previousPageHref}}'>
+        <a
+          class="ui labeled icon button"
+          href="{{pagination.previousPageHref}}"
+        >
           <i class="left chevron icon"></i>
           {{pagination.previousPageIndex}}
         </a>
       {{else}}
         <div class="ui labeled icon disabled button">
           <i class="left chevron icon"></i>
-        </div>      
+        </div>
       {{/if}}
 
       <div class="ui disabled button">
-         {{pagination.currentPageIndex}}
+        {{pagination.currentPageIndex}}
       </div>
 
       {{#if pagination.nextPageIndex}}
-        <a class="ui right labeled icon button" href='{{pagination.nextPageHref}}'>
+        <a
+          class="ui right labeled icon button"
+          href="{{pagination.nextPageHref}}"
+        >
           {{pagination.nextPageIndex}}
           <i class="right chevron icon"></i>
         </a>
       {{else}}
         <div class="ui right labeled icon disabled button">
           <i class="right chevron icon"></i>
-        </div>      
+        </div>
       {{/if}}
     </div>
-
 
     <div class="ui list">
       {{#each hitsData}}
         <div class="item">
           <div class="ui segment">
             <div class="ui blue label">{{this.index}}</div>
-            <a href='{{this.href}}'>{{this.intitule}}</a>
+            <a href="{{this.href}}">{{{this.intitule}}}</a>
             <div class="ui label">{{this.fetch_datetime}}</div>
             <div class="highlight">{{{this.highlight}}}</div>
           </div>
@@ -71,44 +122,52 @@
       {{/each}}
     </div>
 
-
     {{#if pagination.previousPageIndex}}
-      <a class="ui labeled icon button" href='{{pagination.firstPageHref}}'>
+      <a class="ui labeled icon button" href="{{pagination.firstPageHref}}">
         <i class="angle double left icon"></i>
         1
       </a>
     {{else}}
-      <a class="ui labeled icon disabled button" href='{{pagination.firstPageHref}}'>
+      <a
+        class="ui labeled icon disabled button"
+        href="{{pagination.firstPageHref}}"
+      >
         <i class="angle double left icon"></i>
         1
-      </a>     
+      </a>
     {{/if}}
 
     <div class="ui buttons">
       {{#if pagination.previousPageIndex}}
-        <a class="ui labeled icon button" href='{{pagination.previousPageHref}}'>
+        <a
+          class="ui labeled icon button"
+          href="{{pagination.previousPageHref}}"
+        >
           <i class="left chevron icon"></i>
           {{pagination.previousPageIndex}}
         </a>
       {{else}}
         <div class="ui labeled icon disabled button">
           <i class="left chevron icon"></i>
-        </div>      
+        </div>
       {{/if}}
 
       <div class="ui disabled button">
-         {{pagination.currentPageIndex}}
+        {{pagination.currentPageIndex}}
       </div>
 
       {{#if pagination.nextPageIndex}}
-        <a class="ui right labeled icon button" href='{{pagination.nextPageHref}}'>
+        <a
+          class="ui right labeled icon button"
+          href="{{pagination.nextPageHref}}"
+        >
           {{pagination.nextPageIndex}}
           <i class="right chevron icon"></i>
         </a>
       {{else}}
         <div class="ui right labeled icon disabled button">
           <i class="right chevron icon"></i>
-        </div>      
+        </div>
       {{/if}}
     </div>
 


### PR DESCRIPTION
Résoud partiellement #7

Rajout de plusieurs champs de recherche : 
-intitulé
-référence
-organisme

Chaque fois sur un "match"

+ UI : on met en gras au lieu d'italique, plus lisible à mon avis.

Note : Je n'ai testé que sur mon env de dev, c'est à dire avec une vingtaine de documents sur un docker windows. Les performances sont vraiment pas géniales. Je ne sais pas du tout quel impact de performance ces nouveaux champs de recherche pourraient avoir en production, c'est la première fois que je travaille avec ES.